### PR TITLE
Fix/flac format value 0xfffe

### DIFF
--- a/include/wave.h
+++ b/include/wave.h
@@ -59,6 +59,7 @@
 #define WAVE_FORMAT_MPEGLAYER3          (0x0055)
 #define WAVE_FORMAT_G726_ADPCM          (0x0064)
 #define WAVE_FORMAT_G722_ADPCM          (0x0065)
+#define WAVE_FORMAT_EXTENSIBLE          (0xfffe)
 
 #define CD_BLOCK_SIZE                   (2352)
 #define CD_BLOCKS_PER_SEC               (75)

--- a/src/core_wave.c
+++ b/src/core_wave.c
@@ -167,6 +167,7 @@ bool verify_wav_header_internal(wave_info *info,bool verbose)
   }
 
   switch (info->wave_format) {
+    case WAVE_FORMAT_EXTENSIBLE:
     case WAVE_FORMAT_PCM:
       break;
     default:
@@ -511,7 +512,9 @@ char *format_to_str(wshort format)
     case WAVE_FORMAT_G726_ADPCM:
       return "G.726 ADPCM";
     case WAVE_FORMAT_G722_ADPCM:
-      return "G.722 ADPCM";
+      return "G.722 ADPCM";      
+    case WAVE_FORMAT_EXTENSIBLE:
+      return "WAVE Extensible format";
   }
   return "Unknown";
 }

--- a/src/core_wave.c
+++ b/src/core_wave.c
@@ -167,14 +167,17 @@ bool verify_wav_header_internal(wave_info *info,bool verbose)
   }
 
   switch (info->wave_format) {
-    case WAVE_FORMAT_EXTENSIBLE:
     case WAVE_FORMAT_PCM:
+    case WAVE_FORMAT_EXTENSIBLE:
       break;
     default:
       st_warning("unsupported format 0x%04x (%s) while processing file: [%s]",
             info->wave_format,format_to_str(info->wave_format),info->filename);
       return FALSE;
   }
+
+  if(info->wave_format == WAVE_FORMAT_EXTENSIBLE) //Fix format code to PCM for players to support it
+    info->wave_format = WAVE_FORMAT_PCM; 
 
   if (!read_le_short(info->input,&info->channels)) {
     st_warning("reached end of file reading channels while processing file: [%s]",info->filename);


### PR DESCRIPTION
After recent update of flac encoder/decoder format value in WAV header was changed from 0x0001 to 0xfffe, this pull request resolves that issue.

I know that repository is not beeing mainteined, but this pull request could help someone :)